### PR TITLE
[Fix] #29 버킷 상세 조회 시 targetDate, commentID 추가

### DIFF
--- a/src/main/java/com/mybury/waver/dto/bucket/BucketDetailResponse.java
+++ b/src/main/java/com/mybury/waver/dto/bucket/BucketDetailResponse.java
@@ -8,6 +8,7 @@ import com.mybury.waver.domain.User;
 import com.mybury.waver.dto.category.CategoryElement;
 import com.mybury.waver.dto.comment.CommentElement;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +38,7 @@ public record BucketDetailResponse(
     int goalCount,
     int userCount,
     LocalDateTime completedDt,
+    LocalDate targetDate,
     List<KeywordElement> keywords,
     List<FriendElement> friendUsers,
     List<String> images,
@@ -63,6 +65,7 @@ public record BucketDetailResponse(
         bucket.getGoalCount(),
         bucket.getUserCount(),
         bucket.getCompletedDate(),
+        bucket.getTargetDate(),
         keywordList,
         friendUsers,
         images,

--- a/src/main/java/com/mybury/waver/dto/comment/CommentElement.java
+++ b/src/main/java/com/mybury/waver/dto/comment/CommentElement.java
@@ -4,6 +4,7 @@ import com.mybury.waver.common.code.YesNo;
 import com.mybury.waver.domain.Comment;
 
 public record CommentElement(
+    long id,
     YesNo isMyComment,
     long userId,
     String imgUrl,
@@ -13,6 +14,7 @@ public record CommentElement(
 ) {
   public CommentElement(Comment comment, long userId) {
     this(
+        comment.getId(),
         comment.getUserId().equals(userId) ? YesNo.Y : YesNo.N,
         comment.getUserId(),
         comment.getUser().getImgUrl(),


### PR DESCRIPTION
### 수정내용
<img width="229" height="86" alt="image" src="https://github.com/user-attachments/assets/ad704390-eac2-4232-9e98-40d7c9c35baf" />  
<img width="138" height="63" alt="image" src="https://github.com/user-attachments/assets/8e56b8f1-394a-4e90-8b13-4ec9d330952f" />

버킷 상세조회 시 targetDate, commentID 응답하도록 추가 했습니다.


### 이슈 링크
[targetDate](https://trello.com/c/eAjCM6m4/221-%EC%88%98%EC%A0%95-%EB%B2%84%ED%82%B7%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EC%83%81%EC%84%B8%EC%97%90-%EB%94%94%EB%8D%B0%EC%9D%B4-%EB%82%A0%EC%A7%9C%EA%B0%80-%EB%82%B4%EB%A0%A4%EC%98%A4%EC%A7%80-%EC%95%8A%EC%8A%B5%EB%8B%88%EB%8B%A4)
[CommentID](https://trello.com/c/vmekU9dj/236-%EB%B2%84%ED%82%B7%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EC%83%81%EC%84%B8-%EC%9D%91%EB%8B%B5%EA%B0%92-comment-%EC%9D%98-object-%EC%97%90-%EB%8C%93%EA%B8%80id-%EB%8A%94-%EC%97%86%EC%96%B4%EB%8F%84-%EB%90%98%EB%82%98%EC%9A%94-%EC%82%AD%EC%A0%9C%EC%8B%A0%EA%B3%A0-%EB%93%B1%EC%97%90%EC%84%9C-%ED%95%84%EC%9A%94%ED%95%A0-%EA%B2%83-%EA%B0%99%EC%8A%B5%EB%8B%88%EB%8B%A4)